### PR TITLE
Update PickerAttributes bit masks with 2 new values added in OpenCore 0.9.8

### DIFF
--- a/data.json
+++ b/data.json
@@ -87,6 +87,14 @@
       {
         "name": "OC_ATTR_USE_FLAVOUR_ICON",
         "value": "0x80"
+      },
+      {
+        "name": "OC_ATTR_USE_REVERSED_UI",
+        "value": "0x100"
+      },
+      {
+        "name": "OC_ATTR_REDUCE_MOTION",
+        "value": "0x200"
       }
     ],
     "is_hex": true


### PR DESCRIPTION
Added new values to PickerAttributes in data.json:

- `OC_ATTR_USE_REVERSED_UI`
- `OC_ATTR_REDUCE_MOTION`

Both have been added in OpenCore 0.9.8, not released yet. I close the PR for now and reopen it when 0.9.8 is out.

Thanks for your work.